### PR TITLE
:bug: Correctly handle symbol names with digits

### DIFF
--- a/fontawesome7/tex/fontawesome7-utex-helper.sty
+++ b/fontawesome7/tex/fontawesome7-utex-helper.sty
@@ -44,6 +44,7 @@
   \cs_new:Nn\__fontawesome_analyze_font:nn{
     \group_begin:
       \usefont{TU}{fontawesome7#1}{#2}{n}
+      \int_step_inline:nnn {`1} {`9} {\char_set_catcode_letter:n {##1}}
       \int_step_inline:nnnn{67}1{\tex_XeTeXcountglyphs:D \tex_font:D - 1} {
         \tl_set:No\l_tmpa_tl{\tex_XeTeXglyphname:D \tex_font:D ##1}
         \tl_set:NV\l_tmpb_tl\l_tmpa_tl

--- a/fontawesome7/tex/fontawesome7.lua
+++ b/fontawesome7/tex/fontawesome7.lua
@@ -20,8 +20,8 @@ function fontawesome7_analyze_current_font(fontid)
       "\\exp_args:NNc\\tex_global:D\\tex_chardef:D{c__fontawesome_slot_" .. name .. '_char}' .. value .. '\\scan_stop:')
     tex.sprint(
       luatexbase.registernumber("CatcodeTableExpl"),
-      "\\cs_gset_protected:Npn"
-        .. string.gsub('\\fa-' .. name, '-(%w)', string.upper)
+      "\\cs_gset_protected:cpn"
+        .. string.gsub('{fa-' .. name .. "}", '-(%w)', string.upper)
         .. "{\\faPreselectedIcon{" .. name .. "}}")
   end
 end


### PR DESCRIPTION
This pull request addresses a bug that appears when fontawesome is loaded from XeLaTeX or LuaLaTeX.  Those engines parse the font table and automatically define `fa_____` commands.  (In contrast, when fontawesome is loaded from pdfLaTeX, the `fa_____` commands are defined using a static mapping.)  This leads to problems for sets of symbols like `stopwatch` and `stopwatch-20`.  The first of these causes fontawesome to define `\faStopwatch` with no arguments.  The second causes fontawesome to redefine `\faStopwatch` to require a single argument that must be precisely the string `20`.  In LuaLaTeX, the actual order of definitions is arbitrary and varies from run to run.

The solution proposed here is to allow XeLaTeX and LuaLaTeX to define fontawesome symbol names that contain digits (e.g., `\faStopwatch20`).  These cannot conveniently be called from author code, but the fontawesome documentation already specifies that such symbols be called using `\faIcon` (e.g., `\faIcon{stopwatch-20}`).

This pull request resolves #22.