### PR TITLE
fix: Undefined control sequence when compiling with `XeLaTeX`

### DIFF
--- a/fontawesome6/tex/fontawesome6-utex-helper.sty
+++ b/fontawesome6/tex/fontawesome6-utex-helper.sty
@@ -44,7 +44,7 @@
   \cs_new:Nn\__fontawesome_analyze_font:nn{
     \group_begin:
       \usefont{TU}{fontawesome6#1}{#2}{n}
-      \int_step_inline:nnnn{67}1{\tex_XeTeXcountglyphs:D \tex_font:D - 1} {
+      \int_step_inline:nnnn{0}1{\tex_XeTeXcountglyphs:D \tex_font:D - 1} {
         \tl_set:No\l_tmpa_tl{\tex_XeTeXglyphname:D \tex_font:D ##1}
         \tl_set:NV\l_tmpb_tl\l_tmpa_tl
         \tl_put_left:No\l_tmpb_tl{\char_generate:nn{92}{12}fa-}


### PR DESCRIPTION
Address #31 for `fontawesome6`.